### PR TITLE
reading metadata

### DIFF
--- a/hardware/app/include/song_metadata.h
+++ b/hardware/app/include/song_metadata.h
@@ -1,0 +1,15 @@
+// r5_led.h
+// provides led signal to R5 based on amplitude of song
+// communicate with the R5 through shared data
+
+#include <cJSON.h>
+
+#ifndef SONG_METADATA_H
+#define SONG_METADATA_H
+
+void SongMetadata_readMetadataFile(char* metadata_file_name);
+void SongMetadata_nextSong();
+void SongMetadata_previousSong();
+cJSON* SongMetadata_getMetadata();
+
+#endif

--- a/hardware/app/src/joystickFunctionalities.c
+++ b/hardware/app/src/joystickFunctionalities.c
@@ -13,11 +13,13 @@
 #include "hal/joystick.h"
 #include "lcd_draw.h"
 #include "joystickFunctionalities.h"
+#include "song_metadata.h"
 // This will create a thread that constantly monitors joystick inputs and respond appropriately
 
 static pthread_t joystickThread;
 static bool isInitialized = false;
 static bool keepRunning = false;
+static bool playSong = false;
 
 static void* joystick_running(void* arg)
 {
@@ -33,6 +35,20 @@ static void* joystick_running(void* arg)
         } else if (current == DIR_DOWN && volume > 0) {
             WavePlayback_setVolume(volume - 5);
         }
+        else if (current == DIR_RIGHT) {
+            SongMetadata_nextSong();
+        }
+        else if (current == DIR_LEFT) {
+            SongMetadata_previousSong();
+        }
+
+        // used to test getting metadata
+        // if (current == DIR_UP) {
+        //     SongMetadata_nextSong();
+        // }
+        // else if (current == DIR_DOWN) {
+        //     SongMetadata_previousSong();
+        // }
         
         sleep_for_ms(50);
     }

--- a/hardware/app/src/lcd_draw.c
+++ b/hardware/app/src/lcd_draw.c
@@ -18,6 +18,7 @@
 #include "GUI_Paint.h"
 #include "GUI_BMP.h"
 #include "tcp_server.h"
+#include "song_metadata.h"
 
 #include <arpa/inet.h>
 #include <cjson/cJSON.h>
@@ -157,7 +158,7 @@ void Lcd_set_screen(void)
 static bool retrieveUpdateMetadata(void)
 {
     // Retrieve metadata from the server;
-    cJSON *metadata = TCP_getMetadata();
+    cJSON *metadata = SongMetadata_getMetadata();
     if (metadata != NULL) {
         // Get the title from the metadata
         cJSON *title = cJSON_GetObjectItem(metadata, "title");
@@ -167,20 +168,44 @@ static bool retrieveUpdateMetadata(void)
         cJSON *spotify = cJSON_GetObjectItem(metadata, "spotify_url");
         cJSON *apple = cJSON_GetObjectItem(metadata, "apple_music_url");
 
-        char* temp_song_name = "N/A";  // Default value
-        char* temp_artist_name = "N/A";
-        char* temp_album_name = "N/A";
-        char* temp_release_date = "N/A";
-        char* temp_spotify_url = "N/A";
-        char* temp_apple_url = "N/A";
+        // Temporary variables with default values (not yet allocated)
+        char *temp_song_name = NULL;
+        char *temp_artist_name = NULL;
+        char *temp_album_name = NULL;
+        char *temp_release_date = NULL;
+        char *temp_spotify_url = NULL;
+        char *temp_apple_url = NULL;
 
-        if (title && artist && album && release && spotify && apple) {
-            temp_song_name = strdup(title->valuestring);  // Allocate and copy title
+        // Allocate and copy only if the field is a valid string
+        if (cJSON_IsString(title) && title->valuestring != NULL) {
+            temp_song_name = strdup(title->valuestring);
+        } else {
+            temp_song_name = strdup("N/A");
+        }
+        if (cJSON_IsString(artist) && artist->valuestring != NULL) {
             temp_artist_name = strdup(artist->valuestring);
+        } else {
+            temp_artist_name = strdup("N/A");
+        }
+        if (cJSON_IsString(album) && album->valuestring != NULL) {
             temp_album_name = strdup(album->valuestring);
+        } else {
+            temp_album_name = strdup("N/A");
+        }
+        if (cJSON_IsString(release) && release->valuestring != NULL) {
             temp_release_date = strdup(release->valuestring);
+        } else {
+            temp_release_date = strdup("N/A");
+        }
+        if (cJSON_IsString(spotify) && spotify->valuestring != NULL) {
             temp_spotify_url = strdup(spotify->valuestring);
+        } else {
+            temp_spotify_url = strdup("N/A");
+        }
+        if (cJSON_IsString(apple) && apple->valuestring != NULL) {
             temp_apple_url = strdup(apple->valuestring);
+        } else {
+            temp_apple_url = strdup("N/A");
         }
 
         // Compare the song, artist, album to see if we should update.

--- a/hardware/app/src/main.c
+++ b/hardware/app/src/main.c
@@ -8,17 +8,18 @@
 #include "hal/gpio.h"
 #include "hal/i2c.h"
 #include "hal/rotary_encoder.h"
-#include "timeFunction.h"
-#include "rotaryEncoderFunctionalities.h"
 // #include "hal/audioMixer.h"
 #include "hal/joystick.h"
-#include "joystickFunctionalities.h"
-#include "lcd_draw.h"
+#include "hal/micHandler.h"
 #include "hal/wavePlayback.h"
 
-#include "hal/micHandler.h"
+#include "rotaryEncoderFunctionalities.h"
+#include "timeFunction.h"
+#include "lcd_draw.h"
+#include "joystickFunctionalities.h"
 #include "tcp_server.h"
 #include "amplitude_visualizer.h"
+#include "song_metadata.h"
 
 // void audio_amplitude_test() {
 //     WavePlayback_init();
@@ -39,6 +40,7 @@
 int main()
 {
     printf("Starting Program.\n");
+    SongMetadata_readMetadataFile("MusicBoard-audio-files/saved_metadata");
     // audio_amplitude_test();
 
     // Initialize all modules; HAL modules first

--- a/hardware/app/src/song_metadata.c
+++ b/hardware/app/src/song_metadata.c
@@ -1,0 +1,89 @@
+#include <assert.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdatomic.h>
+#include <time.h>
+#include <unistd.h>
+#include "cJSON.h"
+
+static cJSON *metadata_array = 	NULL;
+static cJSON *current_metadata = NULL;
+static int metadata_array_size=0;
+static int metadata_index = 0;
+
+void loadMetadata();
+
+void SongMetadata_readMetadataFile(char* metadata_file_name){
+    if (metadata_array) {
+        cJSON_Delete(metadata_array);
+        metadata_array = NULL;
+    }
+
+    FILE *file = fopen(metadata_file_name, "r");
+    if (!file) {
+        printf("Failed to open metadata file");
+        return;
+    }
+
+    // Get file size
+    fseek(file, 0, SEEK_END);
+    long filesize = ftell(file);
+    rewind(file);
+
+    // Allocate buffer for file contents
+    char *file_contents = (char *)malloc(filesize + 1);
+    if (!file_contents) {
+        perror("Memory allocation failed");
+        fclose(file);
+        return;
+    }
+
+    // Read file into buffer
+    fread(file_contents, 1, filesize, file);
+    file_contents[filesize] = '\0';  // Null-terminate
+
+    // Parse as JSON array
+    metadata_array = cJSON_Parse(file_contents);
+    if (!metadata_array || !cJSON_IsArray(metadata_array)) {
+
+        printf("Error parsing JSON or root is not an array: %s\n", cJSON_GetErrorPtr());
+        cJSON_Delete(metadata_array);  // Clean up just in case
+        metadata_array = NULL;
+    }
+    metadata_array_size = cJSON_GetArraySize(metadata_array);
+	loadMetadata();
+
+    free(file_contents);
+    fclose(file);
+}
+
+void SongMetadata_nextSong(){
+	if(metadata_index < metadata_array_size){
+		metadata_index++;
+		loadMetadata();
+	}
+}
+
+void SongMetadata_previousSong(){
+	if(metadata_index > 0){
+		metadata_index--;
+		loadMetadata();
+	}
+}
+
+cJSON* SongMetadata_getMetadata(){
+	return current_metadata;
+}
+
+void loadMetadata(){
+    if (metadata_array) {
+		current_metadata = cJSON_GetArrayItem(metadata_array, metadata_index);
+		// cJSON *title = cJSON_GetObjectItem(current_metadata, "title");
+		// if (cJSON_IsString(title)) {
+		// 	printf("Song Title: %s\n", title->valuestring);
+		// }
+    }
+}


### PR DESCRIPTION
Added
- saved songs follow the following format for its title '<title>-<artist>'
- saving to /MusicBoard-audio-files/saved_metadata
- added song_metadata.h / .c
    - loads the saved_metadata into an array on startup and whenever metadata is updated
        - if metadata_array  exists, selects current_metadata
    - current_metadata gets controlled by joystick (tested using joystick y) to select songs
    -  metadata displayed on lcd, tested for null values

TODO:
- read x direction for joystick
- play / pause audio of selected song

note:
r5 stuff was commented out to ease testing